### PR TITLE
Upgrade Apache Commons Collection to v3.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     compile 'org.apache.commons:commons-vfs2-project:2.0'
     compile 'commons-validator:commons-validator:1.4.0'
     compile 'commons-logging:commons-logging:1.1.3'
-    compile 'commons-collections:commons-collections:3.2.1'
+    compile 'commons-collections:commons-collections:3.2.2'
 //    compile 'commons-httpclient:commons-httpclient:3.1'
     
     testCompile group: 'junit', name: 'junit', version: '4.+'


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/